### PR TITLE
Use double-ensure to prevent invalid scoped method state

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -2181,11 +2181,16 @@ module ActiveRecord #:nodoc:
             end
           end
 
+          initial_scoped_methods = self.scoped_methods.dup
           self.scoped_methods << method_scoping
           begin
-            yield
+            begin
+              yield
+            ensure
+              self.scoped_methods.replace(initial_scoped_methods)
+            end
           ensure
-            self.scoped_methods.pop
+            self.scoped_methods.replace(initial_scoped_methods)
           end
         end
 


### PR DESCRIPTION
In the previous implementation, an exception (e.g. `Timeout::Error`) being thrown while line 2188 was executing would cause the thread-local `scoped_methods` to incorrectly retain the scope that was about to be cleared, for the life of the process.

By using a double-ensure, we can truly ensure that this does not happen. To wit:
- If an exception occurs while line 2190 is executing, the outer `ensure` block will ensure that line 2193 runs
- If an exception occurs while line 2193 is executing, the inner `ensure` block has already done the necessary work

Of course, if two different thread exceptions take out both `ensure` blocks, we're still in trouble. But that is vanishingly unlikely.
