### PR TITLE
Fixes for postgres 10

### DIFF
--- a/railties/lib/tasks/databases.rake
+++ b/railties/lib/tasks/databases.rake
@@ -283,7 +283,7 @@ namespace :db do
         ENV['PGPASSWORD'] = abcs[RAILS_ENV]["password"].to_s if abcs[RAILS_ENV]["password"]
         search_path = abcs[RAILS_ENV]["schema_search_path"]
         search_path = "--schema=#{search_path}" if search_path
-        `pg_dump -i -U "#{abcs[RAILS_ENV]["username"]}" -s -x -O -f db/#{RAILS_ENV}_structure.sql #{search_path} #{abcs[RAILS_ENV]["database"]}`
+        `pg_dump -U "#{abcs[RAILS_ENV]["username"]}" -s -x -O -f db/#{RAILS_ENV}_structure.sql #{search_path} #{abcs[RAILS_ENV]["database"]}`
         raise "Error dumping database" if $?.exitstatus == 1
       when "sqlite", "sqlite3"
         dbfile = abcs[RAILS_ENV]["database"] || abcs[RAILS_ENV]["dbfile"]


### PR DESCRIPTION
Postgres added a space after the comma in the default search path (which will actually be fixed in the main app now). It also fully removed the -i option that was already deprecated and ignored in 9.4.