### PR TITLE
require rails2_ruby2/action_controller to load route helpers

### DIFF
--- a/Gemfile.2.3.lock
+++ b/Gemfile.2.3.lock
@@ -20,7 +20,7 @@ GEM
     pg (0.21.0)
     power_assert (0.2.6)
     rack (1.6)
-    rails2_ruby2 (1.0.2)
+    rails2_ruby2 (1.0.3)
       iconv
       syck (~> 1.4)
     rake (10.5.0)
@@ -43,7 +43,7 @@ DEPENDENCIES
   nokogiri (= 1.8.0)
   pg
   rack (~> 1.4)
-  rails2_ruby2 (~> 1.0.2)
+  rails2_ruby2 (~> 1.0.3)
   railslts-version!
   rake (~> 10.4)
   rdoc (= 2.5.11)

--- a/Gemfile.2.5.lock
+++ b/Gemfile.2.5.lock
@@ -8,10 +8,11 @@ GEM
   specs:
     RedCloth (4.3.2)
     fcgi (0.9.2.1)
+    iconv (1.0.8)
     libxml-ruby (3.0.0)
     memcache-client (1.8.5)
     mini_portile2 (2.2.0)
-    mocha (0.9.7)
+    mocha (0.9.9)
       rake
     mysql2 (0.2.24)
     nokogiri (1.8.0)
@@ -19,9 +20,13 @@ GEM
     pg (0.21.0)
     power_assert (0.2.6)
     rack (1.4.6)
+    rails2_ruby2 (1.0.3)
+      iconv
+      syck (~> 1.4)
     rake (10.5.0)
     rdoc (2.5.11)
     sqlite3 (1.3.13)
+    syck (1.4.0)
     test-unit (3.1.5)
       power_assert
 
@@ -33,11 +38,12 @@ DEPENDENCIES
   fcgi
   libxml-ruby (= 3.0.0)
   memcache-client
-  mocha (= 0.9.7)
+  mocha (= 0.9.9)
   mysql2 (< 0.3)
   nokogiri (= 1.8.0)
   pg
-  rack (< 1.5)
+  rack (~> 1.4)
+  rails2_ruby2 (~> 1.0.3)
   railslts-version!
   rake (~> 10.4)
   rdoc (= 2.5.11)
@@ -45,4 +51,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -9,7 +9,7 @@ gem 'memcache-client'
 gem 'fcgi'
 
 if RUBY_VERSION >= '2.0'
-  gem 'rails2_ruby2', '~> 1.0.2'
+  gem 'rails2_ruby2', '~> 1.0.3'
 end
 
 if RUBY_VERSION >= '2.4'

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -112,3 +112,4 @@ autoload :Mime, 'action_controller/mime_type'
 autoload :HTML, 'action_controller/vendor/html-scanner'
 
 require 'action_view'
+require 'rails2_ruby2/action_controller'


### PR DESCRIPTION
# What does this PR do?
- requires the `action_controller` patches from `rails2_ruby2`.
- updates `rails2_ruby2` version to `1.0.3`