### PR TITLE
update rails2_ruby2 in gemspec

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'activeresource',   "= #{RailsLts::VERSION::STRING}"
   s.add_dependency 'railties',         "= #{RailsLts::VERSION::STRING}"
   s.add_dependency 'railslts-version', "= #{RailsLts::VERSION::STRING}"
-  s.add_dependency 'rails2_ruby2',     "~> 1.0.2"
+  s.add_dependency 'rails2_ruby2',     "~> 1.0.3"
 end


### PR DESCRIPTION
## What does this PR do?
This updates the `rails2_ruby2` dependency in the gemspec to `1.0.3`