### PR TITLE
allow upgrade of rake for security vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ addons:
     - postgresql-client-10
 before_install:
   - sudo apt-get update && sudo apt-get install libfcgi libfcgi-dev
-  - gem update --system 1.8.25
+  - gem update --system
   - gem --version

--- a/Gemfile.2.3.lock
+++ b/Gemfile.2.3.lock
@@ -51,4 +51,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.2.5.lock
+++ b/Gemfile.2.5.lock
@@ -51,4 +51,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,4 +10,4 @@ DEPENDENCIES
   rake (= 0.8.7)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = ['rails']
   s.rdoc_options = ['--exclude', '.']
 
-  s.add_dependency 'rake',           '>= 0.8.3', '< 11'
+  s.add_dependency 'rake',           '>= 0.8.3', '< 13'
   s.add_dependency 'activesupport',  "= #{RailsLts::VERSION::STRING}"
   s.add_dependency 'actionpack',     "= #{RailsLts::VERSION::STRING}"
 end


### PR DESCRIPTION
Need to upgrade `rake` for security vulnerability [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8)

We are prevented from upgrading by this constraint:
```
activerecord-postgres-hstore (~> 0.6.0) was resolved to 0.6.0, which depends
on
      rails was resolved to 2.3.18.24, which depends on
        railties (= 2.3.18.24) was resolved to 2.3.18.24, which depends on
          rake (>= 0.8.3, < 11)
```