### PR TITLE
Improved usage of kargs in NamedScope.first and .last

### DIFF
--- a/activerecord/lib/active_record/named_scope.rb
+++ b/activerecord/lib/active_record/named_scope.rb
@@ -132,15 +132,15 @@ module ActiveRecord
       end
 
       def first(*args, **kargs)
-        if args.first.kind_of?(Integer) || (@found && !args.first.kind_of?(Hash))
+        if args.first.kind_of?(Integer) || (@found && kargs.empty?)
           proxy_found.first(*args, **kargs)
         else
           find(:first, *args, **kargs)
         end
       end
-
+  
       def last(*args, **kargs)
-        if args.first.kind_of?(Integer) || (@found && !args.first.kind_of?(Hash))
+        if args.first.kind_of?(Integer) || (@found && kargs.empty?)
           proxy_found.last(*args, **kargs)
         else
           find(:last, *args, **kargs)


### PR DESCRIPTION
Jira ticket https://whisper.atlassian.net/browse/GEN-2286

Originally when we updated ActiveRecord::NamedScope::Scope in the ruby 2.7 upgrade (https://github.com/Genius/rails2/pull/16/files#diff-d4df325846b9afecc168b117120a1ee366d998474d3c6527af3daffd17347157L134), we didn't updated the line where it identified if the ordinal arguments contained a hash that could be used as "keyword arguments"
```ruby
      def first(*args)
        if args.first.kind_of?(Integer) || (@found && !args.first.kind_of?(Hash))
          proxy_found.first(*args)
        else
          find(:first, *args)
        end
      end
```

But, after we updated it to include `kargs`, we didn't checked kargs for the keyword arguments, instead we just went ahead and used args, which will never contain a Hashy kind of value (because they get absorved by `kargs`)

```ruby
      def first(*args, **kargs)
        if args.first.kind_of?(Integer) || (@found && !args.first.kind_of?(Hash))
          # Ended in this scenario
          proxy_found.first(*args, **kargs)
        else
          # when it should have used this one
          find(:first, *args, **kargs)
        end
      end
```

Under the right conditions (`@found` being true because of `annotations = Annotation.id_in(params[:annotation_ids])`in `AnnotationsController#bulk_standalone`, and also having present keyword arguments), this made the execution flow to fell into `proxy_found.first(*args, **kargs)` when it should have fell into ` find(:first, *args, **kargs)`

Something to note, is that this exact same issue happens with `.last` but we just didn't had cases using this exact scenario. Now `.last` It's fixed the same way for consistency

This pull request updates the gemfile to point to a fixed version which we'll merge to rails2/2-3-genius-lts once approved and use that branch instead (therefore, this pull request will only include a change in the commit hash in the Gemfile.lock)
