### PR TITLE
CVE-2022-44566: Backport [PATCH] Added integer width check to PostgreSQL::Quoting

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -524,6 +524,14 @@ module ActiveRecord #:nodoc:
     class_inheritable_accessor :default_scoping, :instance_writer => false
     self.default_scoping = []
 
+    ##
+    # :singleton-method:
+    # Application configurable boolean that denotes whether or not to raise
+    # an exception when the PostgreSQLAdapter is provided with an integer that is
+    # wider than signed 64bit representation
+    cattr_accessor :raise_int_wider_than_64bit, :instance_writer => false
+    @@raise_int_wider_than_64bit = true
+
     class << self # Class methods
       # Find operates with four different retrieval approaches:
       #

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -186,6 +186,12 @@ module ActiveRecord
     # * <tt>:min_messages</tt> - An optional client min messages that is used in a <tt>SET client_min_messages TO <min_messages></tt> call on the connection.
     # * <tt>:allow_concurrency</tt> - If true, use async query methods so Ruby threads don't deadlock; otherwise, use blocking query methods.
     class PostgreSQLAdapter < AbstractAdapter
+      class IntegerOutOf64BitRange < StandardError
+        def initialize(msg)
+          super(msg)
+        end
+      end
+
       ADAPTER_NAME = 'PostgreSQL'.freeze
       # get rid of deprecation warnings
       PGconn = defined?(::PG::Connection) ? ::PG::Connection : ::PGconn
@@ -341,8 +347,28 @@ module ActiveRecord
         unescape_bytea(original_value)
       end
 
+      def check_int_in_range(value)
+        if value.to_int > 9223372036854775807 || value.to_int < -9223372036854775808
+          exception = <<-ERROR
+            Provided value outside of the range of a signed 64bit integer.
+
+            PostgreSQL will treat the column type in question as a numeric.
+            This may result in a slow sequential scan due to a comparison
+            being performed between an integer or bigint value and a numeric value.
+
+            To allow for this potentially unwanted behavior, set
+            ActiveRecord::Base.raise_int_wider_than_64bit to false.
+          ERROR
+          raise IntegerOutOf64BitRange.new exception
+        end
+      end
+
       # Quotes PostgreSQL-specific data types for SQL input.
       def quote(value, column = nil) #:nodoc:
+        if ActiveRecord::Base.raise_int_wider_than_64bit && value.is_a?(Integer)
+          check_int_in_range(value)
+        end
+
         if value.kind_of?(String) && column && column.type == :binary
           "'#{escape_bytea(value)}'"
         elsif value.kind_of?(String) && column && column.sql_type == 'xml'

--- a/railties/test/initializer_test.rb
+++ b/railties/test/initializer_test.rb
@@ -436,3 +436,26 @@ class RailsRootTest < Test::Unit::TestCase
   end
 end
 
+class ActiveRecordPostgresSettingsTest < Test::Unit::TestCase
+  def setup
+    @config = Rails::Configuration.new
+    @config.frameworks = [:active_record]
+    @raise_int_wider_than_64bit = ActiveRecord::Base.raise_int_wider_than_64bit
+  end
+
+  def teardown
+    ActiveRecord::Base.raise_int_wider_than_64bit = @raise_int_wider_than_64bit
+  end
+
+  def test_raise_int_wider_than_64bit_is_true_by_default
+    Rails::Initializer.run(:initialize_framework_settings, @config)
+    assert ActiveRecord::Base.raise_int_wider_than_64bit
+  end
+
+  def test_raise_int_wider_than_64bit_can_be_configured
+    @config.active_record.raise_int_wider_than_64bit = false
+
+    Rails::Initializer.run(:initialize_framework_settings, @config)
+    assert !ActiveRecord::Base.raise_int_wider_than_64bit
+  end
+end


### PR DESCRIPTION
Cherry-picked from railslts 145ff1b45b8d105a179dc40addea96e1c18e16bd

<blockquote>Given a value outside the range for a 64bit signed integer type PostgreSQL will treat the column type as numeric. Comparing integer values against numeric values can result in a slow sequential scan.

This behavior is configurable via
ActiveRecord::Base.raise_int_wider_than_64bit which defaults to true.

[CVE-2022-44566]
</blockquote>