### PR TITLE
ruby 2.7: Replace URI.escape and URI.unescape with custom methods

### DIFF
--- a/actionpack/lib/action_controller/caching/actions.rb
+++ b/actionpack/lib/action_controller/caching/actions.rb
@@ -154,7 +154,7 @@ module ActionController #:nodoc:
           path = controller.url_for(options).split('://').last
           normalize!(path)
           add_extension!(path, @extension)
-          @path = URI.unescape(path)
+          @path = URI.unescape_uri(path)
         end
 
         private

--- a/actionpack/lib/action_controller/caching/pages.rb
+++ b/actionpack/lib/action_controller/caching/pages.rb
@@ -97,7 +97,7 @@ module ActionController #:nodoc:
 
         private
           def page_cache_file(path)
-            name = (path.empty? || path == "/") ? "/index" : URI.unescape(path.chomp('/'))
+            name = (path.empty? || path == "/") ? "/index" : URI.unescape_uri(path.chomp('/'))
             name << page_cache_extension unless (name.split('/').last || name).include? '.'
             return name
           end

--- a/actionpack/lib/action_controller/response.rb
+++ b/actionpack/lib/action_controller/response.rb
@@ -70,7 +70,7 @@ module ActionController # :nodoc:
         else
           "#{mime_type}; charset=#{c}"
         end
-      self.headers["Content-Type"] = URI.escape(new_content_type, "\r\n")
+      self.headers["Content-Type"] = URI.escape_unsafe_characters(new_content_type, "\r\n")
     end
 
     # Returns the response's content MIME type, or nil if content type has been set.

--- a/actionpack/lib/action_controller/routing/segments.rb
+++ b/actionpack/lib/action_controller/routing/segments.rb
@@ -36,7 +36,7 @@ module ActionController
       end
 
       def interpolation_chunk
-        URI.escape(value, UNSAFE_PCHAR)
+        URI.escape_unsafe_characters(value, UNSAFE_PCHAR)
       end
 
       # Return a string interpolation statement for this segment and those before it.
@@ -173,7 +173,7 @@ module ActionController
       end
 
       def interpolation_chunk(value_code = local_name)
-        "\#{URI.escape(#{value_code}.to_s, ActionController::Routing::Segment::UNSAFE_PCHAR)}"
+        "\#{URI.escape_unsafe_characters(#{value_code}.to_s, ActionController::Routing::Segment::UNSAFE_PCHAR)}"
       end
 
       def string_structure(prior_segments)
@@ -221,7 +221,7 @@ module ActionController
         default_value = default ? default.inspect : nil
         %[
           value = if (m = match[#{next_capture}])
-            URI.unescape(m)
+            URI.unescape_uri(m)
           else
             #{default_value}
           end
@@ -270,7 +270,7 @@ module ActionController
       end
 
       def extract_value
-        "#{local_name} = hash[:#{key}] && Array(hash[:#{key}]).collect { |path_component| URI.escape(path_component.to_param, ActionController::Routing::Segment::UNSAFE_PCHAR) }.to_param #{"|| #{default.inspect}" if default}"
+        "#{local_name} = hash[:#{key}] && Array(hash[:#{key}]).collect { |path_component| URI.escape_unsafe_characters(path_component.to_param, ActionController::Routing::Segment::UNSAFE_PCHAR) }.to_param #{"|| #{default.inspect}" if default}"
       end
 
       def default
@@ -300,7 +300,7 @@ module ActionController
       class Result < ::Array #:nodoc:
         def to_s() join '/' end
         def self.new_escaped(strings)
-          new strings.collect {|str| URI.unescape str}
+          new strings.collect {|str| URI.unescape_uri str}
         end
       end
     end
@@ -333,7 +333,7 @@ module ActionController
       def match_extraction(next_capture)
         %[
           if (m = match[#{next_capture}])
-            params[:#{key}] = URI.unescape(m.from(1))
+            params[:#{key}] = URI.unescape_uri(m.from(1))
           end
         ]
       end

--- a/actionpack/lib/action_controller/url_rewriter.rb
+++ b/actionpack/lib/action_controller/url_rewriter.rb
@@ -152,7 +152,7 @@ module ActionController
       end
       trailing_slash = options.delete(:trailing_slash) if options.key?(:trailing_slash)
       url << ActionController::Base.relative_url_root.to_s unless options[:skip_relative_url_root]
-      anchor = "##{URI.escape(options.delete(:anchor).to_param.to_s, UNSAFE_PCHAR)}" if options[:anchor]
+      anchor = "##{URI.escape_unsafe_characters(options.delete(:anchor).to_param.to_s, UNSAFE_PCHAR)}" if options[:anchor]
       generated = Routing::Routes.generate(options, {})
       url << (trailing_slash ? generated.sub(/\?|\z/) { "/" + $& } : generated)
       url << anchor if anchor

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,6 +1,6 @@
-if RUBY_VERSION >= '1.9'
-  require 'uri'
+require 'uri'
 
+if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.6' # Fixed in Ruby 2.6 and 2.7
   str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
   str.force_encoding(Encoding::UTF_8) if str.respond_to?(:force_encoding)
 
@@ -8,8 +8,81 @@ if RUBY_VERSION >= '1.9'
     URI::Parser.class_eval do
       remove_method :unescape
       def unescape(str, escaped = @regexp[:ESCAPED])
-        enc = (str.encoding == Encoding::US_ASCII) ? Encoding::UTF_8 : str.encoding
-        str.gsub(escaped) { [$&[1, 2].hex].pack('C') }.force_encoding(enc)
+        ModernRubySupport.unescape_safe_characters(str, escaped)
+      end
+    end
+  end
+end
+
+URI.class_eval do
+  # `URI.escape` and URI.unescape` have been marked "obsolete" for a long time.
+  # Since Ruby 2.7, they always print a warning.
+  #
+  # Usually, calling `URI.unescape` is discouraged and not what you want, but Rails 2.3 uses it exactly that way.
+  # Since we do not want to rewrite Rails' router to fix that, we use a solution similar to modern Rails versions
+  # and ship our own URL encoder and decoder.
+  #
+  # Note that `CGI.escape` or similar core methods behave differently and always escape a specific set of characters.
+  #
+  # Old Ruby version will still call the native URI methods because of paranoia.
+
+  def self.escape_unsafe_characters(string, pattern)
+    if RUBY_VERSION < '2.6'
+      escape(string, pattern)
+    else
+      ModernRubySupport.escape_unsafe_characters(string, pattern)
+    end
+  end
+
+  def self.unescape_uri(string)
+    if RUBY_VERSION < '2.6'
+      unescape(string)
+    else
+      ModernRubySupport.unescape_uri(string)
+    end
+  end
+
+  if RUBY_VERSION >= '1.9'
+    module ModernRubySupport
+      ENCODE   = '%%%02X'.freeze
+      US_ASCII = Encoding::US_ASCII
+      UTF_8    = Encoding::UTF_8
+      EMPTY    = ''.force_encoding(US_ASCII).freeze
+      DEC2HEX  = (0..255).to_a.map { |i| ENCODE % i }.map { |s| s.force_encoding(US_ASCII) }.freeze
+
+      ALPHA = "a-zA-Z".freeze
+      DIGIT = "0-9".freeze
+      UNRESERVED = "#{ALPHA}#{DIGIT}\\-\\._~".freeze
+      SUB_DELIMS = "!\\$&'\\(\\)\\*\\+,;=".freeze
+
+      ESCAPED  = /%[a-fA-F0-9]{2}/.freeze
+
+      FRAGMENT = /[^#{UNRESERVED}#{SUB_DELIMS}:@\/\?]/.freeze
+      SEGMENT  = /[^#{UNRESERVED}#{SUB_DELIMS}:@]/.freeze
+      PATH     = /[^#{UNRESERVED}#{SUB_DELIMS}:@\/]/.freeze
+
+      module_function
+
+      def escape_unsafe_characters(string, pattern)
+        # Passing a 2nd argument to `URI.escape` defines which characters to URI-encode, e.g. `URI.escape(value, "\r\n")`.
+        # This approach is safe, as long as the correct character list or regexp is passed, so we provide a method for
+        # that use case.
+        string.gsub(pattern) { |unsafe| percent_encode(unsafe) }.force_encoding(US_ASCII)
+      end
+
+      def unescape_safe_characters(string, regexp = ESCAPED)
+        encoding = (string.encoding == US_ASCII) ? UTF_8 : string.encoding
+        string.gsub(regexp) { [$&[1, 2].hex].pack('C') }.force_encoding(encoding)
+      end
+
+      def unescape_uri(string)
+        unescape_safe_characters(string, ESCAPED)
+      end
+
+      def percent_encode(unsafe)
+        safe = EMPTY.dup
+        unsafe.each_byte { |b| safe << DEC2HEX[b] }
+        safe
       end
     end
   end

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -6,7 +6,12 @@ class URIExtTest < Test::Unit::TestCase
     str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
     str.force_encoding(Encoding::UTF_8) if str.respond_to?(:force_encoding)
 
-    assert_equal str, URI.unescape(URI.escape(str))
-    assert_equal str, URI.decode(URI.escape(str))
+    Kernel.silence_warnings do # Avoid URI deprecation warnings on Ruby 2.7
+      escaped_str = URI.escape(str).freeze
+
+      assert_equal str, URI.unescape(escaped_str)
+      assert_equal str, URI.decode(escaped_str)
+      assert_equal str, URI.unescape_uri(escaped_str)
+    end
   end
 end


### PR DESCRIPTION
# Description
Changes cherry picked from this Rails LTS commit to address `URI.escape` deprecation and keep support both ruby 2 and ruby 3
https://github.com/makandra/rails/commit/e34e317053a763376ee6b384516330aac48a5e66#diff-8c77d6972714c18dc2c9af1a204cf0d49408f93d25b15eb4dca7d456d2d16851

## Test plan
Automated tests in https://github.com/Genius/Rap-Genius/pull/14973