### PR TITLE
fix: only use the commit titles to display in slack

### DIFF
--- a/.github/workflows/rails_lts_auto_syncer.yaml
+++ b/.github/workflows/rails_lts_auto_syncer.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Grab diff
         id: git-diff
         run: |
-          pretty_diff=$(git rev-list --pretty origin/2-3-lts-for-genius..origin/2-3-lts)
+          pretty_diff=$(git log --pretty=format:"- %s" origin/2-3-lts-for-genius..origin/2-3-lts)
 
           echo "pretty_diff<<EOF" >> $GITHUB_OUTPUT
           echo "$pretty_diff" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description
The last Github Action threw following error
```
Error: The template is not valid. System.InvalidOperationException: Maximum object size exceeded
   at GitHub.DistributedTask.ObjectTemplating.TemplateMemory.AddBytes(Int3[2](https://github.com/Genius/rails2/actions/runs/13791369794/job/38571859321#step:8:2) bytes)
   at GitHub.DistributedTask.ObjectTemplating.TemplateUnraveler.LiteralState..ctor(ReaderState parent, LiteralToken literal, TemplateContext context, Int[3](https://github.com/Genius/rails2/actions/runs/13791369794/job/38571859321#step:8:3)2 removeBytes)
   at GitHub.DistributedTask.ObjectTemplating.TemplateUnraveler.ReaderState.CreateState(ReaderState parent, TemplateToken value, TemplateContext context, Int32 removeBytes)
```

Since we use JS to build the slack message and its `result` object has a limit we need to shrink our slack message

<details>
  <summary>Previous format</summary>

  ```
    commit f5118c06e8379225c9d5a0dd4ec4c57a7987453f
    Author: Tobias Kraze <tobias.kraze@makandra.de>
    Date:   Thu Jan 9 14:20:21 2025 +0100

        drop railslts-version; add tests for deprecated railslts-version gem

    commit 20ca23520360e1c19bcdff9fa39361767dde0f53
    Author: Arne Hartherz <arne.hartherz@makandra.de>
    Date:   Thu Mar 6 15:51:17 2025 +0100

        Rack 1.4.7.21

    commit 43705dbd70482e8021f2ed80ea9aa2fa8e394fe0
    Author: Arne Hartherz <arne.hartherz@makandra.de>
    Date:   Thu Mar 6 15:46:08 2025 +0100

        Backport Rack fix for CVE-2025-27111

    commit b192d52b69e5b436f52a8a32f85b0aabe36891d2
    Author: Dominik Schöler <dominik.schoeler@makandra.de>
    Date:   Fri Feb 21 12:05:52 2025 +0100

        Fix [CVE-2025-25184]: Possible Log Injection in Rack::CommonLogger

    commit 1bf82b27a713da8aa8ab275123421375d994faad
    Author: Tobias Kraze <tobias.kraze@makandra.de>
    Date:   Tue Jan 7 15:40:50 2025 +0100

        activerecord: stabilize a test

    commit 8b7d676135e40f7dc136a0d751da9c6cf86336af
    Author: Dominik Schöler <dominik.schoeler@makandra.de>
    Date:   Thu Oct 17 14:38:36 2024 +0200

        Update LICENSE files
  ```

</details>

<details>
  <summary>New format</summary>
  
  ```
    - drop railslts-version; add tests for deprecated railslts-version gem
    - Rack 1.4.7.21
    - Backport Rack fix for CVE-2025-27111
    - Fix [CVE-2025-25184]: Possible Log Injection in Rack::CommonLogger
    - activerecord: stabilize a test
    - Update LICENSE files
  ```

</details>