### PR TITLE
fix: kwargs in server command

### DIFF
--- a/railties/lib/commands/server.rb
+++ b/railties/lib/commands/server.rb
@@ -100,7 +100,7 @@ app = Rack::Builder.new {
   use Rails::Rack::LogTailer unless options[:detach]
   use Rails::Rack::Debugger if options[:debugger]
   map map_path do
-    use Rails::Rack::Static 
+    use Rails::Rack::Static
     run inner_app
   end
 }.to_app
@@ -118,7 +118,7 @@ end
 puts "=> Ctrl-C to shutdown server"
 
 begin
-  server.run(app, options.merge(:AccessLog => []))
+  server.run(app, **options.merge(:AccessLog => []))
 ensure
   puts 'Exiting'
 end


### PR DESCRIPTION
## Description
Fixing keyword argument in last position
This will allow us to use the `thin` gem in the latest version
This gem is currently used in development and upgrading it would enable us to run the server without docker