### PR TITLE
fix: file used to track changes in rails lts

### DIFF
--- a/.github/workflows/rails_lts_auto_syncer.yaml
+++ b/.github/workflows/rails_lts_auto_syncer.yaml
@@ -17,7 +17,7 @@ jobs:
           git remote add makandra https://github.com/makandra/rails.git
           git fetch makandra 2-3-lts
 
-          n_new_releases=$(git rev-list --count origin/2-3-lts..makandra/2-3-lts -- railslts-version/lib/railslts-version.rb)
+          n_new_releases=$(git rev-list --count origin/2-3-lts..makandra/2-3-lts -- railties/lib/railslts/version.rb)
           if [[ $n_new_releases -eq 0 ]]; then
             echo "cancel=true" >> $GITHUB_OUTPUT
           fi
@@ -33,7 +33,7 @@ jobs:
       - name: Update our copy of rails lts branch to the latest release
         run: |
           workflow_commit_sha=$(git rev-parse HEAD)
-          last_release_commit_sha=$(git rev-list -n 1 makandra/2-3-lts -- railslts-version/lib/railslts-version.rb)
+          last_release_commit_sha=$(git rev-list -n 1 makandra/2-3-lts -- railties/lib/railslts/version.rb)
           git checkout -b 2-3-lts $last_release_commit_sha
           git push --set-upstream origin 2-3-lts
           git checkout $workflow_commit_sha


### PR DESCRIPTION
## Description
We have a workflow that keeps checking for new changes in Rails LTS repository https://github.com/makandra/rails
In a recent change (https://github.com/makandra/rails/commit/f5118c06e8379225c9d5a0dd4ec4c57a7987453f) they moved the versions file to another place which ends up breaking our workflow that check for new releases/version bumps